### PR TITLE
Add npm start and babel-polyfill to package.json

### DIFF
--- a/app.js
+++ b/app.js
@@ -41,5 +41,5 @@ app.use((req, res) => {
   })
 })
 
-console.log('listening on ' + port)
+console.log('Express server listening on port ' + port)
 app.listen(port)

--- a/package.json
+++ b/package.json
@@ -2,8 +2,9 @@
   "name": "complete-intro-to-react",
   "version": "1.0.0",
   "description": "A two day workshop on a complete intro to React",
-  "main": "index.js",
+  "main": "app.js",
   "scripts": {
+    "start": "node app.js",
     "build": "webpack",
     "watch": "webpack --watch",
     "test": "mocha --require test/helpers/setup.js",
@@ -29,6 +30,7 @@
     "babel-preset-es2015": "^6.5.0",
     "babel-preset-react": "^6.5.0",
     "babel-register": "^6.5.2",
+    "babel-polyfill": "^6.7.4",
     "chai": "^3.5.0",
     "enzyme": "^2.0.0",
     "eslint": "^2.2.0",


### PR DESCRIPTION
When I was trying to run the tests I received errors. 
```
Error: Cannot find module 'babel-polyfill'
```
This adds it to the package.json along with `npm start` which makes running the Express server easier for me.   
