### PR TITLE
Fixing typos in code examples on gh-pages

### DIFF
--- a/_posts/2016-01-10-react-state.markdown
+++ b/_posts/2016-01-10-react-state.markdown
@@ -37,8 +37,8 @@ class Search extends React.Component {
           <input type='text' className='search-input' placeholder='Search' />
         </header>
         <div className='shows'>
-          {data.shows.map((show) => (
-            <ShowCard {...show} />
+          {data.shows.map((show, index) => (
+            <ShowCard {...show} key={index} id={index} />
           ))}
         </div>
       </div>
@@ -63,8 +63,8 @@ const Search = React.createClass({
           <input type='text' className='search-input' placeholder='Search' />
         </header>
         <div className='shows'>
-          {data.shows.map((show) => (
-            <ShowCard {...show} />
+          {data.shows.map((show, index) => (
+            <ShowCard {...show} key={index} id={index}/>
           ))}
         </div>
       </div>
@@ -96,8 +96,8 @@ class Search extends React.Component {
           <input type='text' className='search-input' placeholder='Search' />
         </header>
         <div className='shows'>
-          {data.shows.map((show) => (
-            <ShowCard {...show} />
+          {data.shows.map((show, index) => (
+            <ShowCard {...show} key={index} id={index}/>
           ))}
         </div>
       </div>
@@ -138,8 +138,8 @@ class Search extends React.Component {
           <input type='text' className='search-input' placeholder='Search' value={this.state.searchTerm} onChange={this.handleSearchTermChange} />
         </header>
         <div className='shows'>
-          {data.shows.map((show) => (
-            <ShowCard {...show} />
+          {data.shows.map((show, index) => (
+            <ShowCard {...show} key={index} id={index}/>
           ))}
         </div>
       </div>
@@ -158,11 +158,10 @@ Let's make the search actually _do_ something now. Since now we have our state b
 <div className='shows'>
   {data.shows
     .filter((show) => `${show.title} ${show.description}`.toUpperCase().indexOf(this.state.searchTerm.toUpperCase()) >= 0)
-    .map((show) => (
-      <ShowCard {...show} />
+    .map((show, index) => (
+      <ShowCard {...show} key={index} id={index} />
   ))}
 </div>
 {% endhighlight %}
 
 This is a little clever but let's dissect the new filter line we added. We're looking at both the title and description lines to search on and using the indexOf method from strings to see if the searchTerm exists within the description or title. We use toUpperCase on both to make it case agnostic. And the filter method on arrays just filters out items in an array that the method returns false on. Now try typing in your searchBox. You should see it filter as you type. We could make this more efficient but I'll leave that to you in your own time.
-

--- a/_posts/2016-01-14-react-marshall-data.markdown
+++ b/_posts/2016-01-14-react-marshall-data.markdown
@@ -44,7 +44,7 @@ Let's show you a neat debugging tip I totally stole from [Ryan Florence][ryflo].
 
 // at the bottom to shut up lint
 Details.propTypes = {
-  params: React.propType.object
+  params: React.PropTypes.object
 }
 {% endhighlight %}
 
@@ -70,7 +70,7 @@ Now make Search use it
 
 // add propTypes
 Search.propTypes = {
-  shows: React.propTypes.arrayOf(React.propTypes.object)
+  shows: React.PropTypes.arrayOf(React.PropTypes.object)
 }
 {% endhighlight %}
 


### PR DESCRIPTION
- Fixed the section 'React: State'. The code example updated the rendering of the shows, and removed the required `key` and `id` accidentally. I've added them back in.
- Fixed a couple of typos with `PropTypes` on the section on 'Data in React'. 