### PR TITLE
fix for `require.ensure is not a function`

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -18,13 +18,13 @@
   ],
   "env": {
     "server": {
-      "plugins": ["transform-es2015-modules-commonjs"]
+      "plugins": ["transform-es2015-modules-commonjs", "babel-plugin-dynamic-import-node"]
     },
     "development": {
-      "plugins": ["transform-es2015-modules-commonjs"]
+      "plugins": ["transform-es2015-modules-commonjs", "babel-plugin-dynamic-import-node"]
     },
     "test": {
-      "plugins": ["transform-es2015-modules-commonjs"]
+      "plugins": ["transform-es2015-modules-commonjs", "babel-plugin-dynamic-import-node"]
     }
   }
 }


### PR DESCRIPTION
update .babelrc with fix for `TypeError: require.ensure is not a function` issue. Tracked in issue 65.

Fixes: https://github.com/btholt/complete-intro-to-react/issues/65